### PR TITLE
Add tf101 device

### DIFF
--- a/products/AndroidProducts.mk
+++ b/products/AndroidProducts.mk
@@ -13,6 +13,7 @@ PRODUCT_MAKEFILES := \
     $(LOCAL_DIR)/stingray.mk \
     $(LOCAL_DIR)/supersonic.mk \
     $(LOCAL_DIR)/tenderloin.mk \
+    $(LOCAL_DIR)/tf101.mk\
     $(LOCAL_DIR)/toro.mk \
     $(LOCAL_DIR)/vibrantmtd.mk \
     $(LOCAL_DIR)/vivow.mk \

--- a/products/tf101.mk
+++ b/products/tf101.mk
@@ -1,0 +1,21 @@
+# Inherit device configuration for tf101.
+$(call inherit-product, device/asus/tf101/full_tf101.mk)
+
+# Inherit some common cyanogenmod stuff.
+$(call inherit-product, vendor/aokp/configs/common_tablet.mk)
+
+#
+# Setup device specific product configuration.
+#
+PRODUCT_NAME := aokp_tf101
+PRODUCT_BRAND := asus
+PRODUCT_DEVICE := tf101
+PRODUCT_MODEL := EPAD
+PRODUCT_MANUFACTURER := asus
+PRODUCT_BUILD_PROP_OVERRIDES += PRODUCT_NAME=US_epad BUILD_FINGERPRINT=asus/US_epad/EeePad:4.0.3/IML74K/US_epad-9.2.1.11-20120221:user/release-keys PRIVATE_BUILD_DESC="US_epad-user 4.0.3 IML74K US_epad-9.2.1.11-20120221 release-keys"
+
+# Release name and versioning
+PRODUCT_RELEASE_NAME := EeePad
+
+PRODUCT_COPY_FILES +=  \
+    vendor/aokp/prebuilt/common/media/bootanimation.zip:system/media/bootanimation.zip

--- a/vendorsetup.sh
+++ b/vendorsetup.sh
@@ -15,6 +15,7 @@ add_lunch_combo aokp_p4wifi-userdebug
 add_lunch_combo aokp_stingray-userdebug
 add_lunch_combo aokp_supersonic-userdebug
 add_lunch_combo aokp_tenderloin-userdebug
+add_lunch_combo aokp_tf101-userdebug
 add_lunch_combo aokp_vibrantmtd-userdebug
 add_lunch_combo aokp_vivow-userdebug
 add_lunch_combo aokp_wingray-userdebug


### PR DESCRIPTION
Requires forking of the device and vendor trees. You can find both ready to go on my github. Recommend the aokp branches for both.

https://github.com/hillbillyhacker86/android_device_asus_tf101/tree/aokp
https://github.com/hillbillyhacker86/vendor_proprietary_asus_tf101/tree/aokp
