### PR TITLE
Adds lunch and .mk files for Showcase and Mesmerize

### DIFF
--- a/products/AndroidProducts.mk
+++ b/products/AndroidProducts.mk
@@ -6,10 +6,12 @@ PRODUCT_MAKEFILES := \
     $(LOCAL_DIR)/captivatemtd.mk \
     $(LOCAL_DIR)/fascinatemtd.mk \
     $(LOCAL_DIR)/galaxysmtd.mk \
+    $(LOCAL_DIR)/mesmerizemtd.mk \
     $(LOCAL_DIR)/otter.mk \
     $(LOCAL_DIR)/p4.mk \
     $(LOCAL_DIR)/p4vzw.mk \
     $(LOCAL_DIR)/p4wifi.mk \
+    $(LOCAL_DIR)/showcasemtd.mk \
     $(LOCAL_DIR)/stingray.mk \
     $(LOCAL_DIR)/supersonic.mk \
     $(LOCAL_DIR)/tenderloin.mk \

--- a/products/mesmerizemtd.mk
+++ b/products/mesmerizemtd.mk
@@ -1,0 +1,23 @@
+$(call inherit-product, device/samsung/mesmerizemtd/full_mesmerizemtd.mk)
+
+# Release name
+PRODUCT_RELEASE_NAME := Mesmerize
+
+$(call inherit-product, vendor/aokp/configs/common_phone.mk)
+
+PRODUCT_PACKAGE_OVERLAYS += vendor/aokp/overlay/aries-common
+
+# $(call inherit-product, vendor/cm/config/gsm.mk)
+
+## Device identifier. This must come after all inclusions
+PRODUCT_DEVICE := mesmerizemtd
+PRODUCT_NAME := aokp_mesmerizemtd
+PRODUCT_BRAND := samsung
+PRODUCT_MODEL := SCH-I500
+
+#Set build fingerprint / ID / Prduct Name ect.
+PRODUCT_BUILD_PROP_OVERRIDES += PRODUCT_NAME=SCH-I500 TARGET_DEVICE=SCH-I500 BUILD_ID=IML74K BUILD_FINGERPRINT=google/soju/crespo:2.3.4/GRJ22/121341:user/release-keys PRIVATE_BUILD_DESC="soju-user 2.3.4 GRJ22 121341 release-keys"
+
+# boot animation
+PRODUCT_COPY_FILES += \
+	vendor/aokp/prebuilt/common/media/bootanimation.zip:system/media/bootanimation.zip

--- a/products/showcasemtd.mk
+++ b/products/showcasemtd.mk
@@ -1,0 +1,23 @@
+$(call inherit-product, device/samsung/showcasemtd/full_showcasemtd.mk)
+
+# Release name
+PRODUCT_RELEASE_NAME := Showcase
+
+$(call inherit-product, vendor/aokp/configs/common_phone.mk)
+
+PRODUCT_PACKAGE_OVERLAYS += vendor/aokp/overlay/aries-common
+
+# $(call inherit-product, vendor/cm/config/gsm.mk)
+
+## Device identifier. This must come after all inclusions
+PRODUCT_DEVICE := showcasemtd
+PRODUCT_NAME := aokp_showcasemtd
+PRODUCT_BRAND := samsung
+PRODUCT_MODEL := SCH-I500
+
+#Set build fingerprint / ID / Prduct Name ect.
+PRODUCT_BUILD_PROP_OVERRIDES += PRODUCT_NAME=SCH-I500 TARGET_DEVICE=SCH-I500 BUILD_ID=IML74K BUILD_FINGERPRINT=google/soju/crespo:2.3.4/GRJ22/121341:user/release-keys PRIVATE_BUILD_DESC="soju-user 2.3.4 GRJ22 121341 release-keys"
+
+# boot animation
+PRODUCT_COPY_FILES += \
+	vendor/aokp/prebuilt/common/media/bootanimation.zip:system/media/bootanimation.zip

--- a/vendorsetup.sh
+++ b/vendorsetup.sh
@@ -9,11 +9,13 @@ add_lunch_combo aokp_fascinatemtd-userdebug
 add_lunch_combo aokp_galaxysmtd-userdebug
 add_lunch_combo aokp_galaxytab7c-userdebug
 add_lunch_combo aokp_inc-userdebug
+add_lunch_combo aokp_mesmerizemtd-userdebug
 add_lunch_combo aokp_otter-userdebug
 add_lunch_combo aokp_p4-userdebug
 add_lunch_combo aokp_p4vzw-userdebug
 add_lunch_combo aokp_p4wifi-userdebug
 add_lunch_combo aokp_p5wifi-userdebug
+add_lunch_combo aokp_showcasemtd-userdebug
 add_lunch_combo aokp_stingray-userdebug
 add_lunch_combo aokp_supersonic-userdebug
 add_lunch_combo aokp_tenderloin-userdebug


### PR DESCRIPTION
You can fork the device trees from
https://github.com/Stevespear426/android_device_samsung_mesmerizemtd
https://github.com/Stevespear426/android_device_samsung_showcase
They don't need vendor prop files because they use the fascinate props.
